### PR TITLE
Resources for grant & default privileges.

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -97,7 +97,7 @@ type Client struct {
 	catalogLock sync.RWMutex
 }
 
-// NewClient returns new client config
+// NewClient returns client config for the specified database.
 func (c *Config) NewClient(database string) (*Client, error) {
 	dbRegistryLock.Lock()
 	defer dbRegistryLock.Unlock()
@@ -110,8 +110,10 @@ func (c *Config) NewClient(database string) (*Client, error) {
 			return nil, errors.Wrap(err, "could not connect to PostgreSQL server")
 		}
 
-		// only one connection
-		db.SetMaxIdleConns(1)
+		// We don't want to retain connection
+		// So when we connect on a specific database which might be managed by terraform,
+		// we don't keep opened connection in case of the db will destroyed
+		db.SetMaxIdleConns(0)
 		db.SetMaxOpenConns(c.MaxConns)
 
 		version, err := fingerprintCapabilities(db)

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -1,8 +1,13 @@
 package postgresql
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
 )
 
 // pqQuoteLiteral returns a string literal safe for inclusion in a PostgreSQL
@@ -21,4 +26,95 @@ func validateConnLimit(v interface{}, key string) (warnings []string, errors []e
 		errors = append(errors, fmt.Errorf("%s can not be less than -1", key))
 	}
 	return
+}
+
+func sliceContainsStr(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+var allowedPrivileges = map[string][]string{
+	"table":    []string{"ALL", "SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"},
+	"sequence": []string{"ALL", "USAGE", "SELECT", "UPDATE"},
+}
+
+func validatePrivileges(objectType string, privileges []interface{}) error {
+	allowed, ok := allowedPrivileges[objectType]
+	if !ok {
+		return fmt.Errorf("unknown object type %s", objectType)
+	}
+
+	for _, priv := range privileges {
+		if !sliceContainsStr(allowed, priv.(string)) {
+			return fmt.Errorf("%s is not an allowed privilege for object type %s", priv, objectType)
+		}
+	}
+	return nil
+}
+
+func pgArrayToSet(arr pq.ByteaArray) *schema.Set {
+	s := make([]interface{}, len(arr))
+	for i, v := range arr {
+		s[i] = string(v)
+	}
+	return schema.NewSet(schema.HashString, s)
+}
+
+func startTransaction(client *Client, database string) (*sql.Tx, error) {
+	// TODO: Think about serialization level
+
+	if database != "" && database != client.databaseName {
+		var err error
+		client, err = client.config.NewClient(database)
+		if err != nil {
+			return nil, err
+		}
+	}
+	db := client.DB()
+	txn, err := db.Begin()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not start transaction")
+	}
+
+	return txn, nil
+}
+
+func dbExists(txn *sql.Tx, dbname string) (bool, error) {
+	err := txn.QueryRow("SELECT datname from pg_database WHERE datname=$1", dbname).Scan(&dbname)
+	switch {
+	case err == sql.ErrNoRows:
+		return false, nil
+	case err != nil:
+		return false, errors.Wrap(err, "could not check if database exists")
+	}
+
+	return true, nil
+}
+
+func roleExists(txn *sql.Tx, rolname string) (bool, error) {
+	err := txn.QueryRow("SELECT 1 FROM pg_roles WHERE rolname=$1", rolname).Scan(&rolname)
+	switch {
+	case err == sql.ErrNoRows:
+		return false, nil
+	case err != nil:
+		return false, errors.Wrap(err, "could not check if role exists")
+	}
+
+	return true, nil
+}
+
+func schemaExists(txn *sql.Tx, schemaname string) (bool, error) {
+	err := txn.QueryRow("SELECT 1 FROM pg_namespace WHERE nspname=$1", schemaname).Scan(&schemaname)
+	switch {
+	case err == sql.ErrNoRows:
+		return false, nil
+	case err != nil:
+		return false, errors.Wrap(err, "could not check if schema exists")
+	}
+
+	return true, nil
 }

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -84,10 +84,12 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"postgresql_database":  resourcePostgreSQLDatabase(),
-			"postgresql_extension": resourcePostgreSQLExtension(),
-			"postgresql_schema":    resourcePostgreSQLSchema(),
-			"postgresql_role":      resourcePostgreSQLRole(),
+			"postgresql_database":           resourcePostgreSQLDatabase(),
+			"postgresql_extension":          resourcePostgreSQLExtension(),
+			"postgresql_schema":             resourcePostgreSQLSchema(),
+			"postgresql_role":               resourcePostgreSQLRole(),
+			"postgresql_grant":              resourcePostgreSQLGrant(),
+			"postgresql_default_privileges": resourcePostgreSQLDefaultPrivileges(),
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -133,7 +135,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		Host:              d.Get("host").(string),
 		Port:              d.Get("port").(int),
-		Database:          d.Get("database").(string),
 		Username:          d.Get("username").(string),
 		Password:          d.Get("password").(string),
 		SSLMode:           sslMode,
@@ -143,7 +144,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		ExpectedVersion:   version,
 	}
 
-	client, err := config.NewClient()
+	client, err := config.NewClient(d.Get("database").(string))
 	if err != nil {
 		return nil, errwrap.Wrapf("Error initializing PostgreSQL client: {{err}}", err)
 	}

--- a/postgresql/resource_postgresql_database.go
+++ b/postgresql/resource_postgresql_database.go
@@ -259,20 +259,13 @@ func resourcePostgreSQLDatabaseDelete(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourcePostgreSQLDatabaseExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	c := meta.(*Client)
-	c.catalogLock.RLock()
-	defer c.catalogLock.RUnlock()
-
-	var dbName string
-	err := c.DB().QueryRow("SELECT d.datname from pg_database d WHERE datname=$1", d.Id()).Scan(&dbName)
-	switch {
-	case err == sql.ErrNoRows:
-		return false, nil
-	case err != nil:
+	txn, err := startTransaction(meta.(*Client), "")
+	if err != nil {
 		return false, err
 	}
+	defer txn.Rollback()
 
-	return true, nil
+	return dbExists(txn, d.Id())
 }
 
 func resourcePostgreSQLDatabaseRead(d *schema.ResourceData, meta interface{}) error {

--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -1,0 +1,221 @@
+package postgresql
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/pkg/errors"
+	// Use Postgres as SQL driver
+	"github.com/lib/pq"
+)
+
+// TODO: manage global default privileges (no schema)
+func resourcePostgreSQLDefaultPrivileges() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePostgreSQLDefaultPrivilegesCreate,
+		Update: resourcePostgreSQLDefaultPrivilegesCreate,
+		Read:   resourcePostgreSQLDefaultPrivilegesRead,
+		Delete: resourcePostgreSQLDefaultPrivilegesDelete,
+
+		Schema: map[string]*schema.Schema{
+			"role": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the role to which grant default privileges",
+			},
+			"database": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The database on which grant default privileges for this role",
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Role for which apply default privileges (You can change default privileges only for objects that will be created by yoursSHOW FULL PROCESSLIST  elf or by roles that you are a member of)",
+			},
+			"schema": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"object_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"table",
+					"sequence",
+				}, false),
+			},
+			"privileges": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+				MinItems: 1,
+			},
+		},
+	}
+}
+
+func resourcePostgreSQLDefaultPrivilegesRead(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*Client)
+	exists, err := checkRoleDBSchemaExists(client, d)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		return nil
+	}
+
+	txn, err := startTransaction(client, d.Get("database").(string))
+	if err != nil {
+		return err
+	}
+	defer txn.Rollback()
+
+	return readRoleDefaultPrivileges(txn, d)
+}
+
+func resourcePostgreSQLDefaultPrivilegesCreate(d *schema.ResourceData, meta interface{}) error {
+	if err := validatePrivileges(d.Get("object_type").(string), d.Get("privileges").(*schema.Set).List()); err != nil {
+		return err
+	}
+
+	client := meta.(*Client)
+	role := d.Get("role").(string)
+	database := d.Get("database").(string)
+	schema := d.Get("schema").(string)
+
+	txn, err := startTransaction(client, database)
+	if err != nil {
+		return err
+	}
+	defer txn.Rollback()
+
+	// Revoke all privileges before granting otherwise reducing privileges will not work.
+	// We just have to revoke them in the same transaction so role will not lost his privileges between revoke and grant.
+	if err = revokeRoleDefaultPrivileges(txn, d); err != nil {
+		return err
+	}
+
+	if err = grantRoleDefaultPrivileges(txn, d); err != nil {
+		return err
+	}
+
+	if err := txn.Commit(); err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%s-%s-%s", role, database, schema))
+
+	txn, err = startTransaction(client, d.Get("database").(string))
+	if err != nil {
+		return err
+	}
+	defer txn.Rollback()
+
+	return readRoleDefaultPrivileges(txn, d)
+}
+
+func resourcePostgreSQLDefaultPrivilegesDelete(d *schema.ResourceData, meta interface{}) error {
+	txn, err := startTransaction(meta.(*Client), d.Get("database").(string))
+	if err != nil {
+		return err
+	}
+	defer txn.Rollback()
+
+	revokeRoleDefaultPrivileges(txn, d)
+	if err := txn.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func readRoleDefaultPrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	role := d.Get("role").(string)
+	pgSchema := d.Get("schema").(string)
+
+	query := `SELECT array_agg(prtype) FROM (
+		SELECT defaclnamespace, (aclexplode(defaclacl)).* FROM pg_default_acl
+	) AS t (namespace, grantor_oid, grantee_oid, prtype, grantable)
+
+	JOIN pg_roles ON grantee_oid = pg_roles.oid 
+	JOIN pg_namespace ON pg_namespace.oid = namespace 
+
+	WHERE rolname = $1 AND nspname = $2;
+`
+	var privileges pq.ByteaArray
+
+	if err := txn.QueryRow(query, role, pgSchema).Scan(&privileges); err != nil {
+		return errors.Wrap(err, "could not read default privileges")
+	}
+
+	// We consider no privileges as "not exists"
+	if len(privileges) == 0 {
+		log.Printf("[DEBUG] no default privileges for role %s in schema %s", role, pgSchema)
+		d.SetId("")
+		return nil
+	}
+
+	privilegesSet := pgArrayToSet(privileges)
+	d.Set("privileges", privilegesSet)
+
+	return nil
+}
+
+func grantRoleDefaultPrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	role := d.Get("role").(string)
+	database := d.Get("database").(string)
+	pgSchema := d.Get("schema").(string)
+
+	privileges := []string{}
+	for _, priv := range d.Get("privileges").(*schema.Set).List() {
+		privileges = append(privileges, priv.(string))
+	}
+
+	// TODO: We grant default privileges for the DB owner
+	// For that we need to be either superuser or a member of the owner role.
+	// For RDS it will not be the case so the solution may be to grant the owner role
+	// to the connected user
+
+	query := fmt.Sprintf("ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s GRANT %s ON %sS TO %s",
+		pq.QuoteIdentifier(d.Get("owner").(string)),
+		pq.QuoteIdentifier(pgSchema),
+		strings.Join(privileges, ","),
+		strings.ToUpper(d.Get("object_type").(string)),
+		pq.QuoteIdentifier(role),
+	)
+
+	_, err := txn.Exec(
+		query,
+	)
+	if err != nil {
+		return errors.Wrap(err, "could not alter default privileges")
+	}
+
+	d.SetId(role + "-" + database + "-" + pgSchema)
+	return nil
+}
+
+func revokeRoleDefaultPrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	query := fmt.Sprintf(
+		"ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s REVOKE ALL ON %sS FROM %s",
+		pq.QuoteIdentifier(d.Get("owner").(string)),
+		pq.QuoteIdentifier(d.Get("schema").(string)),
+		strings.ToUpper(d.Get("object_type").(string)),
+		pq.QuoteIdentifier(d.Get("role").(string)),
+	)
+
+	_, err := txn.Exec(query)
+	return err
+}

--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -37,7 +37,7 @@ func resourcePostgreSQLDefaultPrivileges() *schema.Resource {
 			"owner": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Role for which apply default privileges (You can change default privileges only for objects that will be created by yoursSHOW FULL PROCESSLIST  elf or by roles that you are a member of)",
+				Description: "Role for which apply default privileges (You can change default privileges only for objects that will be created by yourself or by roles that you are a member of)",
 			},
 			"schema": {
 				Type:     schema.TypeString,

--- a/postgresql/resource_postgresql_default_privileges_test.go
+++ b/postgresql/resource_postgresql_default_privileges_test.go
@@ -1,0 +1,49 @@
+package postgresql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccPostgresqlDefaultPrivileges(t *testing.T) {
+	// We have to create the database outside of resource.Test
+	// because we need to create a table to assert that grant are correctly applied
+	// and we don't have this resource yet
+	dbSuffix, teardown := setupTestDatabase(t, true, true, false)
+	defer teardown()
+
+	config := getTestConfig(t)
+	dbName, roleName := getTestDBNames(dbSuffix)
+
+	// We set PGUSER as owner as he will create the test table
+	var testDPSelect = fmt.Sprintf(`
+	resource "postgresql_default_privileges" "test_ro" {
+		database    = "%s"
+		owner       = "%s"
+		role        = "%s"
+		schema      = "public"
+		object_type = "table"
+		privileges   = ["SELECT"]
+	}
+	`, dbName, config.Username, roleName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDPSelect,
+				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						return testCheckTablePrivileges(t, dbSuffix, []string{"SELECT"}, true)
+					},
+					resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.#", "1"),
+					resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.3138006342", "SELECT"),
+				),
+			},
+		},
+	})
+}

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -1,0 +1,274 @@
+package postgresql
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/pkg/errors"
+	// Use Postgres as SQL driver
+	"github.com/lib/pq"
+)
+
+var objectTypes = map[string]string{
+	"table":    "r",
+	"sequence": "S",
+}
+
+func resourcePostgreSQLGrant() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePostgreSQLGrantCreate,
+		// As create revokes and grants we can use it to update too
+		Update: resourcePostgreSQLGrantCreate,
+		Read:   resourcePostgreSQLGrantRead,
+		Delete: resourcePostgreSQLGrantDelete,
+
+		// TODO: fill descriptions
+		Schema: map[string]*schema.Schema{
+			"role": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the role to which grant privileges",
+			},
+			"database": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The database on which grant privileges for this role",
+			},
+			"schema": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"object_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"table",
+					"sequence",
+				}, false),
+			},
+			"privileges": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+				MinItems: 1,
+			},
+		},
+	}
+}
+
+func resourcePostgreSQLGrantRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+	exists, err := checkRoleDBSchemaExists(client, d)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		return nil
+	}
+
+	txn, err := startTransaction(client, d.Get("database").(string))
+	if err != nil {
+		return err
+	}
+	defer txn.Rollback()
+
+	return readRolePrivileges(txn, d)
+}
+
+func resourcePostgreSQLGrantCreate(d *schema.ResourceData, meta interface{}) error {
+	if err := validatePrivileges(d.Get("object_type").(string), d.Get("privileges").(*schema.Set).List()); err != nil {
+		return err
+	}
+
+	client := meta.(*Client)
+	role := d.Get("role").(string)
+	database := d.Get("database").(string)
+
+	txn, err := startTransaction(client, database)
+	if err != nil {
+		return err
+	}
+	defer txn.Rollback()
+
+	// Revoke all privileges before granting otherwise reducing privileges will not work.
+	// We just have to revoke them in the same transaction so role will not lost his privileges between revoke and grant.
+	if err = revokeRolePrivileges(txn, d); err != nil {
+		return err
+	}
+
+	if err = grantRolePrivileges(txn, d); err != nil {
+		return err
+	}
+
+	if err = txn.Commit(); err != nil {
+		return errors.Wrap(err, "could not commit transaction")
+	}
+
+	d.SetId(fmt.Sprintf("%s-%s-%s", role, database, d.Get("schema").(string)))
+
+	txn, err = startTransaction(client, database)
+	if err != nil {
+		return err
+	}
+	defer txn.Rollback()
+
+	return readRolePrivileges(txn, d)
+}
+
+func resourcePostgreSQLGrantDelete(d *schema.ResourceData, meta interface{}) error {
+	txn, err := startTransaction(meta.(*Client), d.Get("database").(string))
+	if err != nil {
+		return err
+	}
+	defer txn.Rollback()
+
+	if err = revokeRolePrivileges(txn, d); err != nil {
+		return err
+	}
+
+	if err = txn.Commit(); err != nil {
+		return errors.Wrap(err, "could not commit transaction")
+	}
+
+	return nil
+}
+
+func readRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	query := `
+SELECT pg_class.relname, array_remove(array_agg(privilege_type), NULL)
+FROM pg_class
+JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+LEFT JOIN (
+    SELECT acls.* FROM (
+        SELECT relname, relnamespace, relkind, (aclexplode(relacl)).* FROM pg_class c
+    ) as acls
+    JOIN pg_roles on grantee = pg_roles.oid
+    WHERE rolname=$1
+) privs
+USING (relname, relnamespace, relkind)
+WHERE nspname = $2 AND relkind = $3
+GROUP BY pg_class.relname;
+`
+
+	objectType := d.Get("object_type").(string)
+	rows, err := txn.Query(
+		query, d.Get("role"), d.Get("schema"), objectTypes[objectType],
+	)
+	if err != nil {
+		return err
+	}
+
+	for rows.Next() {
+		var objName string
+		var privileges pq.ByteaArray
+
+		if err := rows.Scan(&objName, &privileges); err != nil {
+			return err
+		}
+		privilegesSet := pgArrayToSet(privileges)
+
+		if !privilegesSet.Equal(d.Get("privileges").(*schema.Set)) {
+			// If an object has not the same privileges as saved in the state,
+			// we return an empty privileges to force an update.
+			log.Printf(
+				"[DEBUG] %s %s has not the expected privileges %v for role %s",
+				strings.ToTitle(objectType), objName, privileges, d.Get("role"),
+			)
+			d.Set("privileges", schema.NewSet(schema.HashString, []interface{}{}))
+			break
+		}
+
+	}
+
+	return nil
+}
+
+func grantRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	privileges := []string{}
+	for _, priv := range d.Get("privileges").(*schema.Set).List() {
+		privileges = append(privileges, priv.(string))
+	}
+
+	query := fmt.Sprintf(
+		"GRANT %s ON ALL %sS IN SCHEMA %s TO %s",
+		strings.Join(privileges, ","),
+		strings.ToUpper(d.Get("object_type").(string)),
+		pq.QuoteIdentifier(d.Get("schema").(string)),
+		pq.QuoteIdentifier(d.Get("role").(string)),
+	)
+
+	_, err := txn.Exec(query)
+	return err
+}
+
+func revokeRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	query := fmt.Sprintf(
+		"REVOKE ALL PRIVILEGES ON ALL %sS IN SCHEMA %s FROM %s",
+		strings.ToUpper(d.Get("object_type").(string)),
+		pq.QuoteIdentifier(d.Get("schema").(string)),
+		pq.QuoteIdentifier(d.Get("role").(string)),
+	)
+
+	_, err := txn.Exec(query)
+	return err
+}
+
+func checkRoleDBSchemaExists(client *Client, d *schema.ResourceData) (bool, error) {
+	txn, err := startTransaction(client, "")
+	if err != nil {
+		return false, err
+	}
+	defer txn.Rollback()
+
+	// Check that role exists
+	role := d.Get("role").(string)
+	exists, err := roleExists(txn, role)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		log.Printf("[DEBUG] role %s does not exists", role)
+		return false, nil
+	}
+
+	// Check that database exists
+	database := d.Get("database").(string)
+	exists, err = dbExists(txn, database)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		log.Printf("[DEBUG] database %s does not exists", database)
+		return false, nil
+	}
+
+	// Connect on this database to check if schema exists
+	dbTxn, err := startTransaction(client, database)
+	if err != nil {
+		return false, err
+	}
+	defer dbTxn.Rollback()
+
+	// Check that schema exists ( be connected on the right database for that)
+	pgSchema := d.Get("schema").(string)
+	exists, err = schemaExists(txn, pgSchema)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		log.Printf("[DEBUG] schema %s does not exists", pgSchema)
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/postgresql/resource_postgresql_grant_test.go
+++ b/postgresql/resource_postgresql_grant_test.go
@@ -1,0 +1,67 @@
+package postgresql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccPostgresqlGrant(t *testing.T) {
+	// We have to create the database outside of resource.Test
+	// because we need to create a table to assert that grant are correctly applied
+	// and we don't have this resource yet
+	dbSuffix, teardown := setupTestDatabase(t, true, true, true)
+	defer teardown()
+
+	dbName, roleName := getTestDBNames(dbSuffix)
+	var testGrantSelect = fmt.Sprintf(`
+	resource "postgresql_grant" "test_ro" {
+		database    = "%s"
+		role        = "%s"
+		schema      = "public"
+		object_type = "table"
+		privileges   = ["SELECT"]
+	}
+	`, dbName, roleName)
+
+	var testGrantSelectInsertUpdate = fmt.Sprintf(`
+	resource "postgresql_grant" "test_ro" {
+		database    = "%s"
+		role        = "%s"
+		schema      = "public"
+		object_type = "table"
+		privileges   = ["SELECT", "INSERT", "UPDATE"]
+	}
+	`, dbName, roleName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testGrantSelect,
+				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						return testCheckTablePrivileges(t, dbSuffix, []string{"SELECT"}, false)
+					},
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.#", "1"),
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.3138006342", "SELECT"),
+				),
+			},
+			{
+				Config: testGrantSelectInsertUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						return testCheckTablePrivileges(t, dbSuffix, []string{"SELECT", "INSERT", "UPDATE"}, false)
+					},
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.#", "3"),
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.3138006342", "SELECT"),
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.892623219", "INSERT"),
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.1759376126", "UPDATE"),
+				),
+			},
+		},
+	})
+}

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -280,6 +280,9 @@ func resourcePostgreSQLRoleCreate(d *schema.ResourceData, meta interface{}) erro
 
 func resourcePostgreSQLRoleDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Client)
+	client.catalogLock.Lock()
+	defer client.catalogLock.Unlock()
+
 	txn, err := startTransaction(client, "")
 	if err != nil {
 		return err
@@ -440,6 +443,8 @@ func resourcePostgreSQLRoleReadImpl(client *Client, txn *sql.Tx, d *schema.Resou
 
 func resourcePostgreSQLRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Client)
+	client.catalogLock.Lock()
+	defer client.catalogLock.Unlock()
 
 	txn, err := startTransaction(client, "")
 	if err != nil {

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -259,6 +259,10 @@ func resourcePostgreSQLRoleCreate(d *schema.ResourceData, meta interface{}) erro
 		return errors.Wrapf(err, "error creating role %s", roleName)
 	}
 
+	if err = grantRoles(txn, d); err != nil {
+		return err
+	}
+
 	if err = txn.Commit(); err != nil {
 		return errors.Wrap(err, "could not commit transaction")
 	}

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -74,13 +74,17 @@ func TestAccPostgresqlRole_Update(t *testing.T) {
 			{
 				Config: testAccPostgresqlRoleUpdate2Config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlRoleExists("tf_tests_update_role", []string{"group_role"}),
-					resource.TestCheckResourceAttr("postgresql_role.update_role", "name", "tf_tests_update_role"),
+					testAccCheckPostgresqlRoleExists("tf_tests_update_role2", []string{"tf_tests_group_role"}),
+					resource.TestCheckResourceAttr(
+						"postgresql_role.update_role", "name", "tf_tests_update_role2",
+					),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "login", "true"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "connection_limit", "5"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "roles.#", "1"),
 					// The int part in the attr name is the schema.HashString of the value.
-					resource.TestCheckResourceAttr("postgresql_role.update_role", "roles.2117325082", "group_role"),
+					resource.TestCheckResourceAttr(
+						"postgresql_role.update_role", "roles.2634717634", "tf_tests_group_role",
+					),
 				),
 			},
 		},

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -3,10 +3,13 @@ package postgresql
 import (
 	"database/sql"
 	"fmt"
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/lib/pq"
 )
 
 func TestAccPostgresqlRole_Basic(t *testing.T) {
@@ -18,8 +21,13 @@ func TestAccPostgresqlRole_Basic(t *testing.T) {
 			{
 				Config: testAccPostgresqlRoleConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlRoleExists("postgresql_role.myrole2", "true"),
-					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "name", "testing_role_with_defaults"),
+					testAccCheckPostgresqlRoleExists("tf_tests_myrole2", nil),
+					resource.TestCheckResourceAttr("postgresql_role.myrole2", "name", "tf_tests_myrole2"),
+					resource.TestCheckResourceAttr("postgresql_role.myrole2", "login", "true"),
+					resource.TestCheckResourceAttr("postgresql_role.myrole2", "roles.#", "0"),
+
+					testAccCheckPostgresqlRoleExists("tf_tests_role_default", nil),
+					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "name", "tf_tests_role_default"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "superuser", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "create_database", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "create_role", "false"),
@@ -32,6 +40,15 @@ func TestAccPostgresqlRole_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "valid_until", "infinity"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "skip_drop_role", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "skip_reassign_owned", "false"),
+					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "roles.#", "0"),
+
+					testAccCheckPostgresqlRoleExists("tf_tests_sub_role", []string{"tf_tests_myrole2", "tf_tests_role_simple"}),
+					resource.TestCheckResourceAttr("postgresql_role.sub_role", "name", "tf_tests_sub_role"),
+					resource.TestCheckResourceAttr("postgresql_role.sub_role", "roles.#", "2"),
+
+					// The int part in the attr name is the schema.HashString of the value.
+					resource.TestCheckResourceAttr("postgresql_role.sub_role", "roles.1456111905", "tf_tests_myrole2"),
+					resource.TestCheckResourceAttr("postgresql_role.sub_role", "roles.3803627293", "tf_tests_role_simple"),
 				),
 			},
 		},
@@ -47,19 +64,23 @@ func TestAccPostgresqlRole_Update(t *testing.T) {
 			{
 				Config: testAccPostgresqlRoleUpdate1Config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlRoleExists("postgresql_role.update_role", "true"),
-					resource.TestCheckResourceAttr("postgresql_role.update_role", "name", "update_role"),
+					testAccCheckPostgresqlRoleExists("tf_tests_update_role", []string{}),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "name", "tf_tests_update_role"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "login", "true"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "connection_limit", "-1"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "roles.#", "0"),
 				),
 			},
 			{
 				Config: testAccPostgresqlRoleUpdate2Config,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlRoleExists("postgresql_role.update_role", "true"),
-					resource.TestCheckResourceAttr("postgresql_role.update_role", "name", "update_role2"),
+					testAccCheckPostgresqlRoleExists("tf_tests_update_role", []string{"group_role"}),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "name", "tf_tests_update_role"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "login", "true"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "connection_limit", "5"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "roles.#", "1"),
+					// The int part in the attr name is the schema.HashString of the value.
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "roles.2117325082", "group_role"),
 				),
 			},
 		},
@@ -75,7 +96,6 @@ func testAccCheckPostgresqlRoleDestroy(s *terraform.State) error {
 		}
 
 		exists, err := checkRoleExists(client, rs.Primary.ID)
-
 		if err != nil {
 			return fmt.Errorf("Error checking role %s", err)
 		}
@@ -88,25 +108,11 @@ func testAccCheckPostgresqlRoleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckPostgresqlRoleExists(n string, canLogin string) resource.TestCheckFunc {
+func testAccCheckPostgresqlRoleExists(roleName string, grantedRoles []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Resource not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		actualCanLogin := rs.Primary.Attributes["login"]
-		if actualCanLogin != canLogin {
-			return fmt.Errorf("Wrong value for login expected %s got %s", canLogin, actualCanLogin)
-		}
-
 		client := testAccProvider.Meta().(*Client)
-		exists, err := checkRoleExists(client, rs.Primary.ID)
 
+		exists, err := checkRoleExists(client, roleName)
 		if err != nil {
 			return fmt.Errorf("Error checking role %s", err)
 		}
@@ -115,6 +121,9 @@ func testAccCheckPostgresqlRoleExists(n string, canLogin string) resource.TestCh
 			return fmt.Errorf("Role not found")
 		}
 
+		if grantedRoles != nil {
+			return checkGrantedRoles(client, roleName, grantedRoles)
+		}
 		return nil
 	}
 }
@@ -132,36 +141,63 @@ func checkRoleExists(client *Client, roleName string) (bool, error) {
 	return true, nil
 }
 
+func checkGrantedRoles(client *Client, roleName string, expectedRoles []string) error {
+
+	var grantedRoles pq.ByteaArray
+
+	err := client.DB().QueryRow(
+		"SELECT array_agg(role_name::text ORDER BY role_name) FROM information_schema.applicable_roles WHERE grantee=$1",
+		roleName,
+	).Scan(&grantedRoles)
+	if err != nil {
+		return fmt.Errorf("Error reading granted roles: %v", err)
+	}
+
+	grantedRolesArr := []string{}
+	for _, v := range grantedRoles {
+		grantedRolesArr = append(grantedRolesArr, string(v))
+	}
+
+	sort.Strings(expectedRoles)
+	if !reflect.DeepEqual(grantedRolesArr, expectedRoles) {
+		return fmt.Errorf(
+			"Role %s is not a members of the expected list of roles. expected %v - got %v",
+			roleName, expectedRoles, grantedRolesArr,
+		)
+	}
+	return nil
+}
+
 var testAccPostgresqlRoleConfig = `
 resource "postgresql_role" "myrole2" {
-  name = "myrole2"
+  name = "tf_tests_myrole2"
   login = true
 }
 
 resource "postgresql_role" "role_with_pwd" {
-  name = "role_with_pwd"
+  name = "tf_tests_role_with_pwd"
   login = true
   password = "mypass"
 }
 
 resource "postgresql_role" "role_with_pwd_encr" {
-  name = "role_with_pwd_encr"
+  name = "tf_tests_role_with_pwd_encr"
   login = true
   password = "mypass"
   encrypted = true
 }
 
 resource "postgresql_role" "role_with_pwd_no_login" {
-  name = "role_with_pwd_no_login"
+  name = "tf_tests_role_with_pwd_no_login"
   password = "mypass"
 }
 
 resource "postgresql_role" "role_simple" {
-  name = "role_simple"
+  name = "tf_tests_role_simple"
 }
 
 resource "postgresql_role" "role_with_defaults" {
-  name = "testing_role_with_defaults"
+  name = "tf_tests_role_default"
   superuser = false
   create_database = false
   create_role = false
@@ -176,19 +212,31 @@ resource "postgresql_role" "role_with_defaults" {
   skip_reassign_owned = false
   valid_until = "infinity"
 }
+
+resource "postgresql_role" "sub_role" {
+	name = "tf_tests_sub_role"
+	roles = [
+		"${postgresql_role.myrole2.id}",
+		"${postgresql_role.role_simple.id}",
+	]
+}
 `
 
 var testAccPostgresqlRoleUpdate1Config = `
 resource "postgresql_role" "update_role" {
-  name = "update_role"
+  name = "tf_tests_update_role"
   login = true
 }
 `
 
 var testAccPostgresqlRoleUpdate2Config = `
+resource "postgresql_role" "group_role" {
+	name = "tf_tests_group_role"
+}
 resource "postgresql_role" "update_role" {
-  name = "update_role2"
+  name = "tf_tests_update_role2"
   login = true
   connection_limit = 5
+  roles = ["${postgresql_role.group_role.name}"]
 }
 `

--- a/postgresql/testing.go
+++ b/postgresql/testing.go
@@ -1,0 +1,147 @@
+package postgresql
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	dbNamePrefix     = "tf_tests_db"
+	roleNamePrefix   = "tf_tests_role"
+	testRolePassword = "testpwd"
+
+	testTableDef = "CREATE TABLE test_table (val text)"
+)
+
+func getTestConfig(t *testing.T) Config {
+	getEnv := func(key, fallback string) string {
+		value := os.Getenv(key)
+		if len(value) == 0 {
+			return fallback
+		}
+		return value
+	}
+
+	dbPort, err := strconv.Atoi(getEnv("PGPORT", "5432"))
+	if err != nil {
+		t.Fatalf("could not cast PGPORT value as integer: %v", err)
+	}
+
+	return Config{
+		Host:     getEnv("PGHOST", "localhost"),
+		Port:     dbPort,
+		Username: getEnv("PGUSER", ""),
+		Password: getEnv("PGPASSWORD", ""),
+	}
+}
+
+// dbExecute is a test helper to create a pool, execute one query then close the pool
+func dbExecute(t *testing.T, dsn, query string, args ...interface{}) {
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Fatalf("could to create connection pool: %v", err)
+	}
+	defer db.Close()
+
+	// Create the test DB
+	if _, err = db.Exec(query, args...); err != nil {
+		t.Fatalf("could not execute query %s: %v", query, err)
+	}
+}
+
+func getTestDBNames(dbSuffix string) (dbName string, roleName string) {
+	dbName = fmt.Sprintf("%s_%s", dbNamePrefix, dbSuffix)
+	roleName = fmt.Sprintf("%s_%s", roleNamePrefix, dbSuffix)
+
+	return
+}
+
+// setupTestDatabase creates all needed resources before executing a terraform test
+// and provides the teardown function to delete all these resources.
+func setupTestDatabase(t *testing.T, createDB, createRole, createTable bool) (string, func()) {
+	config := getTestConfig(t)
+
+	suffix := strconv.Itoa(int(time.Now().UnixNano()))
+
+	dbName, roleName := getTestDBNames(suffix)
+
+	if createDB {
+		dbExecute(t, config.connStr("postgres"), fmt.Sprintf("CREATE DATABASE %s", dbName))
+	}
+	if createRole {
+		dbExecute(t, config.connStr("postgres"), fmt.Sprintf(
+			"CREATE ROLE %s LOGIN ENCRYPTED PASSWORD '%s'",
+			roleName, testRolePassword,
+		))
+	}
+
+	if createTable {
+		// Create a test table in this new database
+		dbExecute(t, config.connStr(dbName), testTableDef)
+	}
+
+	return suffix, func() {
+		dbExecute(t, config.connStr("postgres"), fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName))
+		dbExecute(t, config.connStr("postgres"), fmt.Sprintf("DROP ROLE IF EXISTS %s", roleName))
+	}
+}
+
+func testCheckTablePrivileges(
+	t *testing.T, dbSuffix string, allowedPrivileges []string, createTable bool,
+) error {
+	config := getTestConfig(t)
+
+	dbName, roleName := getTestDBNames(dbSuffix)
+
+	// Some test (e.g.: default privileges) need the test table to be created only now
+	if createTable {
+		db, err := sql.Open("postgres", config.connStr(dbName))
+		if err != nil {
+			t.Fatalf("could not open connection pool for db %s: %v", dbName, err)
+		}
+		defer db.Close()
+
+		if _, err := db.Exec(testTableDef); err != nil {
+			t.Fatalf("could not create test table in db %s: %v", dbName, err)
+		}
+		// In this case we need to drop table after each test.
+		defer func() {
+			db.Exec("DROP TABLE test_table")
+		}()
+	}
+
+	// Connect as the test role
+	config.Username = roleName
+	config.Password = testRolePassword
+
+	db, err := sql.Open("postgres", config.connStr(dbName))
+	if err != nil {
+		t.Fatalf("could not open connection pool for db %s: %v", dbName, err)
+	}
+	defer db.Close()
+
+	queries := map[string]string{
+		"SELECT": "SELECT count(*) FROM test_table",
+		"INSERT": "INSERT INTO test_table VALUES ('test')",
+		"UPDATE": "UPDATE test_table SET val = 'test'",
+		"DELETE": "DELETE FROM test_table",
+	}
+
+	for queryType, query := range queries {
+		_, err := db.Exec(query)
+
+		if err != nil && sliceContainsStr(allowedPrivileges, queryType) {
+			return errors.Wrapf(err, "could not %s on test table", queryType)
+
+		} else if err == nil && !sliceContainsStr(allowedPrivileges, queryType) {
+			return errors.Wrapf(err, "%s did not failed as expected", queryType)
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
@@ -1,0 +1,11 @@
+package structure
+
+import "encoding/json"
+
+func ExpandJsonFromString(jsonString string) (map[string]interface{}, error) {
+	var result map[string]interface{}
+
+	err := json.Unmarshal([]byte(jsonString), &result)
+
+	return result, err
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
@@ -1,0 +1,16 @@
+package structure
+
+import "encoding/json"
+
+func FlattenJsonToString(input map[string]interface{}) (string, error) {
+	if len(input) == 0 {
+		return "", nil
+	}
+
+	result, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+
+	return string(result), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
@@ -1,0 +1,24 @@
+package structure
+
+import "encoding/json"
+
+// Takes a value containing JSON string and passes it through
+// the JSON parser to normalize it, returns either a parsing
+// error or normalized JSON string.
+func NormalizeJsonString(jsonString interface{}) (string, error) {
+	var j interface{}
+
+	if jsonString == nil || jsonString.(string) == "" {
+		return "", nil
+	}
+
+	s := jsonString.(string)
+
+	err := json.Unmarshal([]byte(s), &j)
+	if err != nil {
+		return s, err
+	}
+
+	bytes, _ := json.Marshal(j)
+	return string(bytes[:]), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
@@ -1,0 +1,21 @@
+package structure
+
+import (
+	"reflect"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func SuppressJsonDiff(k, old, new string, d *schema.ResourceData) bool {
+	oldMap, err := ExpandJsonFromString(old)
+	if err != nil {
+		return false
+	}
+
+	newMap, err := ExpandJsonFromString(new)
+	if err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(oldMap, newMap)
+}

--- a/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
+++ b/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
@@ -1,0 +1,146 @@
+package validation
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/structure"
+)
+
+// IntBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is between min and max (inclusive)
+func IntBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v < min || v > max {
+			es = append(es, fmt.Errorf("expected %s to be in the range (%d - %d), got %d", k, min, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntAtLeast returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at least min (inclusive)
+func IntAtLeast(min int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v < min {
+			es = append(es, fmt.Errorf("expected %s to be at least (%d), got %d", k, min, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntAtMost returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at most max (inclusive)
+func IntAtMost(max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v > max {
+			es = append(es, fmt.Errorf("expected %s to be at most (%d), got %d", k, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// StringInSlice returns a SchemaValidateFunc which tests if the provided value
+// is of type string and matches the value of an element in the valid slice
+// will test with in lower case if ignoreCase is true
+func StringInSlice(valid []string, ignoreCase bool) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		for _, str := range valid {
+			if v == str || (ignoreCase && strings.ToLower(v) == strings.ToLower(str)) {
+				return
+			}
+		}
+
+		es = append(es, fmt.Errorf("expected %s to be one of %v, got %s", k, valid, v))
+		return
+	}
+}
+
+// StringLenBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type string and has length between min and max (inclusive)
+func StringLenBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+		if len(v) < min || len(v) > max {
+			es = append(es, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %s", k, min, max, v))
+		}
+		return
+	}
+}
+
+// CIDRNetwork returns a SchemaValidateFunc which tests if the provided value
+// is of type string, is in valid CIDR network notation, and has significant bits between min and max (inclusive)
+func CIDRNetwork(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		_, ipnet, err := net.ParseCIDR(v)
+		if err != nil {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid CIDR, got: %s with err: %s", k, v, err))
+			return
+		}
+
+		if ipnet == nil || v != ipnet.String() {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid network CIDR, expected %s, got %s",
+				k, ipnet, v))
+		}
+
+		sigbits, _ := ipnet.Mask.Size()
+		if sigbits < min || sigbits > max {
+			es = append(es, fmt.Errorf(
+				"expected %q to contain a network CIDR with between %d and %d significant bits, got: %d",
+				k, min, max, sigbits))
+		}
+
+		return
+	}
+}
+
+func ValidateJsonString(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := structure.NormalizeJsonString(v); err != nil {
+		errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
+	}
+	return
+}

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors) [![Sourcegraph](https://sourcegraph.com/github.com/pkg/errors/-/badge.svg)](https://sourcegraph.com/github.com/pkg/errors?badge)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## License
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,282 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which when applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// together with the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required, the errors.WithStack and
+// errors.WithMessage functions destructure errors.Wrap into its component
+// operations: annotating an error with a stack trace and with a message,
+// respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error that does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// Although the causer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported:
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively.
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface:
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// The returned errors.StackTrace type is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// Although the stackTracer interface is not exported by this package, it is
+// considered a part of its stable public interface.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is called, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+// WithMessagef annotates err with the format specifier.
+// If err is nil, WithMessagef returns nil.
+func WithMessagef(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg: fmt.Sprintf(format, args...),
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,147 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   function name and path of source file relative to the compile time
+//          GOPATH separated by \n\t (<funcname>\n\t<path>)
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -472,6 +472,14 @@
 			"versionExact": "v0.10.0"
 		},
 		{
+			"checksumSHA1": "Fzbv+N7hFXOtrR6E7ZcHT3jEE9s=",
+			"path": "github.com/hashicorp/terraform/helper/structure",
+			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
+			"revisionTime": "2017-08-02T18:39:14Z",
+			"version": "v0.10.0",
+			"versionExact": "v0.10.0"
+		},
+		{
 			"checksumSHA1": "qsI85GvNukAIUv+kcy8CdgP7um8=",
 			"path": "github.com/hashicorp/terraform/helper/validation",
 			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
@@ -563,6 +571,12 @@
 			"path": "github.com/mitchellh/reflectwalk",
 			"revision": "92573fe8d000a145bfebc03a16bc22b34945867f",
 			"revisionTime": "2016-10-03T17:45:16Z"
+		},
+		{
+			"checksumSHA1": "DTy0iJ2w5C+FDsN9EnzfhNmvS+o=",
+			"path": "github.com/pkg/errors",
+			"revision": "059132a15dd08d6704c67711dae0cf35ab991756",
+			"revisionTime": "2018-10-23T23:59:46Z"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -472,6 +472,14 @@
 			"versionExact": "v0.10.0"
 		},
 		{
+			"checksumSHA1": "qsI85GvNukAIUv+kcy8CdgP7um8=",
+			"path": "github.com/hashicorp/terraform/helper/validation",
+			"revision": "2041053ee9444fa8175a298093b55a89586a1823",
+			"revisionTime": "2017-08-02T18:39:14Z",
+			"version": "v0.10.0",
+			"versionExact": "v0.10.0"
+		},
+		{
 			"checksumSHA1": "yFWmdS6yEJZpRJzUqd/mULqCYGk=",
 			"path": "github.com/hashicorp/terraform/moduledeps",
 			"revision": "5bcc1bae5925f44208a83279b6d4d250da01597b",


### PR DESCRIPTION
This PR:

* Adds ``postgresql_grant`` and ``postgresql_default_privileges`` resources to manage privileges for ``table`` and ``sequence`` objects (can probably be easily extended to other object type.)

* Adds a ``roles`` field in ``postgresql_role`` which allows to grant membership to one or more other roles.

I created the PR so we can start to talk about it but there's still a bit of work to do:

- [ ] Think about transaction isolation level. I used transaction instead of lock like it was done but we may have to specified a right isolation to avoid dead lock.
- [x] Fix existing tests
- [x] Add tests for these new resources.
