### PR TITLE
We have some conflicts if we don't lock it.

### DIFF
--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -68,8 +68,11 @@ func resourcePostgreSQLDefaultPrivileges() *schema.Resource {
 }
 
 func resourcePostgreSQLDefaultPrivilegesRead(d *schema.ResourceData, meta interface{}) error {
-
 	client := meta.(*Client)
+
+	client.catalogLock.RLock()
+	defer client.catalogLock.RUnlock()
+
 	exists, err := checkRoleDBSchemaExists(client, d)
 	if err != nil {
 		return err
@@ -93,8 +96,12 @@ func resourcePostgreSQLDefaultPrivilegesCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	client := meta.(*Client)
 	database := d.Get("database").(string)
+
+	client := meta.(*Client)
+
+	client.catalogLock.Lock()
+	defer client.catalogLock.Unlock()
 
 	txn, err := startTransaction(client, database)
 	if err != nil {
@@ -128,7 +135,12 @@ func resourcePostgreSQLDefaultPrivilegesCreate(d *schema.ResourceData, meta inte
 }
 
 func resourcePostgreSQLDefaultPrivilegesDelete(d *schema.ResourceData, meta interface{}) error {
-	txn, err := startTransaction(meta.(*Client), d.Get("database").(string))
+	client := meta.(*Client)
+
+	client.catalogLock.Lock()
+	defer client.catalogLock.Unlock()
+
+	txn, err := startTransaction(client, d.Get("database").(string))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Example:
When two default privileges are applied for the same owner/schema/object_type
(e.g.: one for a read only role and one for read write role), this may upate the same tuple in the database and fail.