### PR TITLE
grant/schema: grant owners to connected user.

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -92,7 +92,7 @@ func revokeRoleMembership(db QueryAble, role, member string) error {
 	return nil
 }
 
-// withRolesGranted temporary grants, if needed, the roles specified to connected user
+// withRolesGranted temporarily grants, if needed, the roles specified to connected user
 // (i.e.: the admin configure in the provider) and revoke them as soon as the
 // callback func has finished.
 func withRolesGranted(txn *sql.Tx, roles []string, fn func() error) error {
@@ -101,14 +101,14 @@ func withRolesGranted(txn *sql.Tx, roles []string, fn func() error) error {
 		return err
 	}
 
-	var granted []string
+	var grantedRoles []string
 	for _, role := range roles {
 		roleGranted, err := grantRoleMembership(txn, role, currentUser)
 		if err != nil {
 			return err
 		}
 		if roleGranted {
-			granted = append(granted, role)
+			grantedRoles = append(grantedRoles, role)
 		}
 	}
 
@@ -116,9 +116,8 @@ func withRolesGranted(txn *sql.Tx, roles []string, fn func() error) error {
 		return err
 	}
 
-	for _, role := range granted {
-		err := revokeRoleMembership(txn, role, currentUser)
-		if err != nil {
+	for _, role := range grantedRoles {
+		if err := revokeRoleMembership(txn, role, currentUser); err != nil {
 			return err
 		}
 	}

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -238,7 +238,6 @@ func getCurrentUser(db QueryAble) (string, error) {
 	case err != nil:
 		return "", errwrap.Wrapf("error while looking for the current user: {{err}}", err)
 	}
-
 	return currentUser, nil
 }
 

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -141,19 +141,16 @@ func resourcePostgreSQLGrantCreate(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	if err = withRolesGranted(txn, owners, func() error {
-
+	if err := withRolesGranted(txn, owners, func() error {
 		// Revoke all privileges before granting otherwise reducing privileges will not work.
 		// We just have to revoke them in the same transaction so the role will not lost its
 		// privileges between the revoke and grant statements.
-		if err = revokeRolePrivileges(txn, d); err != nil {
+		if err := revokeRolePrivileges(txn, d); err != nil {
 			return err
 		}
-
-		if err = grantRolePrivileges(txn, d); err != nil {
+		if err := grantRolePrivileges(txn, d); err != nil {
 			return err
 		}
-
 		return nil
 	}); err != nil {
 		return err
@@ -198,7 +195,7 @@ func resourcePostgreSQLGrantDelete(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	if err = withRolesGranted(txn, owners, func() error {
+	if err := withRolesGranted(txn, owners, func() error {
 		return revokeRolePrivileges(txn, d)
 	}); err != nil {
 		return err

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -125,6 +125,7 @@ func resourcePostgreSQLGrantCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	database := d.Get("database").(string)
+	schemaName := d.Get("schema").(string)
 
 	client.catalogLock.Lock()
 	defer client.catalogLock.Unlock()
@@ -135,14 +136,26 @@ func resourcePostgreSQLGrantCreate(d *schema.ResourceData, meta interface{}) err
 	}
 	defer deferredRollback(txn)
 
-	// Revoke all privileges before granting otherwise reducing privileges will not work.
-	// We just have to revoke them in the same transaction so the role will not lost its
-	// privileges between the revoke and grant statements.
-	if err = revokeRolePrivileges(txn, d); err != nil {
+	owners, err := getRolesToGrantForSchema(txn, schemaName)
+	if err != nil {
 		return err
 	}
 
-	if err = grantRolePrivileges(txn, d); err != nil {
+	if err = withRolesGranted(txn, owners, func() error {
+
+		// Revoke all privileges before granting otherwise reducing privileges will not work.
+		// We just have to revoke them in the same transaction so the role will not lost its
+		// privileges between the revoke and grant statements.
+		if err = revokeRolePrivileges(txn, d); err != nil {
+			return err
+		}
+
+		if err = grantRolePrivileges(txn, d); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
 		return err
 	}
 
@@ -180,7 +193,14 @@ func resourcePostgreSQLGrantDelete(d *schema.ResourceData, meta interface{}) err
 	}
 	defer deferredRollback(txn)
 
-	if err = revokeRolePrivileges(txn, d); err != nil {
+	owners, err := getRolesToGrantForSchema(txn, d.Get("schema").(string))
+	if err != nil {
+		return err
+	}
+
+	if err = withRolesGranted(txn, owners, func() error {
+		return revokeRolePrivileges(txn, d)
+	}); err != nil {
 		return err
 	}
 
@@ -409,4 +429,24 @@ func generateGrantID(d *schema.ResourceData) string {
 	parts = append(parts, objectType)
 
 	return strings.Join(parts, "_")
+}
+
+func getRolesToGrantForSchema(txn *sql.Tx, schemaName string) ([]string, error) {
+	// If user we use for Terraform is not a superuser (e.g.: in RDS)
+	// we need to grant owner of the schema and owners of tables in the schema
+	// in order to change theirs permissions.
+	owners, err := getTablesOwner(txn, schemaName)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaOwner, err := getSchemaOwner(txn, schemaName)
+	if err != nil {
+		return nil, err
+	}
+	if !sliceContainsStr(owners, schemaOwner) {
+		owners = append(owners, schemaOwner)
+	}
+
+	return owners, nil
 }

--- a/postgresql/resource_postgresql_schema.go
+++ b/postgresql/resource_postgresql_schema.go
@@ -151,10 +151,9 @@ func resourcePostgreSQLSchemaCreate(d *schema.ResourceData, meta interface{}) er
 
 	}
 
-	err = withRolesGranted(txn, rolesToGrant, func() error {
+	if err = withRolesGranted(txn, rolesToGrant, func() error {
 		return createSchema(d, c, txn)
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/postgresql/resource_postgresql_schema.go
+++ b/postgresql/resource_postgresql_schema.go
@@ -151,7 +151,7 @@ func resourcePostgreSQLSchemaCreate(d *schema.ResourceData, meta interface{}) er
 
 	}
 
-	if err = withRolesGranted(txn, rolesToGrant, func() error {
+	if err := withRolesGranted(txn, rolesToGrant, func() error {
 		return createSchema(d, c, txn)
 	}); err != nil {
 		return err


### PR DESCRIPTION
If the configured admin user in the provider is not superuser,
we need to temporarily grant to it the roles owning objects we are modifying.

